### PR TITLE
feat: add apple-inspired ui theme

### DIFF
--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -5,20 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@ViewData["Title"] - SqlDummySeeder</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <style>
-        .stepper { display:flex; gap:8px; align-items:center; margin: 16px 0; }
-        .step { padding:6px 12px; border-radius:999px; background:#eee; color:#333; }
-        .step.active { background:#0d6efd; color:#fff; }
-        .step.done { background:#20c997; color:#fff; }
-        .table-fixed { max-height: 50vh; overflow:auto; }
-        .monospace { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
-        textarea.monospace { font-size: 0.9rem; }
-    </style>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
+    <link rel="stylesheet" href="~/css/site.css" />
 </head>
 <body>
     <div class="container py-3">
         <header class="mb-3 d-flex align-items-center gap-3">
-            <h3 class="mb-0">SQL Dummy Seeder</h3>
+            <h3 class="mb-0"><i class="bi bi-apple"></i> SQL Dummy Seeder</h3>
             <span class="text-muted">Kết nối → Chọn bảng → Seed dữ liệu (FK-aware)</span>
         </header>
         <main role="main" class="pb-3">

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -1,0 +1,66 @@
+body {
+    background: linear-gradient(180deg, #f5f5f7 0%, #ffffff 100%);
+    color: #1d1d1f;
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif;
+}
+
+header h3 {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+header h3 i {
+    font-size: 1.5rem;
+    color: #555;
+}
+
+.card {
+    border: none;
+    border-radius: 20px;
+    box-shadow: 0 4px 10px rgba(0,0,0,0.08);
+    animation: fadeIn .6s ease;
+    transition: transform .25s ease, box-shadow .25s ease;
+}
+
+.card:hover {
+    transform: scale(1.02);
+    box-shadow: 0 8px 20px rgba(0,0,0,0.15);
+}
+
+.btn-primary {
+    background-color: #0071e3;
+    border: none;
+    border-radius: 10px;
+    transition: background-color .3s ease, transform .2s ease;
+}
+
+.btn-primary:hover {
+    background-color: #005bb5;
+    transform: scale(1.05);
+}
+
+.stepper .step {
+    background: #e5e5ea;
+    color: #1d1d1f;
+    transition: background-color .3s ease, color .3s ease;
+}
+
+.stepper .step.active {
+    background: #0071e3;
+    color: #fff;
+}
+
+.stepper .step.done {
+    background: #20c997;
+    color: #fff;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(10px); }
+    to { opacity: 1; transform: none; }
+}
+
+.table-fixed { max-height: 50vh; overflow:auto; }
+.monospace { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
+textarea.monospace { font-size: 0.9rem; }


### PR DESCRIPTION
## Summary
- add custom CSS with Apple-inspired fonts, colors, and animations
- include bootstrap icons and Apple glyph in layout

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a9eb10e93c832abaedc493fbd1355b