### PR TITLE
chore: upgrade to dotnet 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 - Giữ toàn bộ tính năng seed (FK-aware, Rules JSON, Bogus, fixes nvarchar(max)/varchar(max), Truncate an toàn).
 
 ## Run
+Yêu cầu [.NET 9 SDK](https://dotnet.microsoft.com/download/dotnet/9.0).
+
 ```bash
 dotnet restore
 dotnet run

--- a/SqlDummySeeder.csproj
+++ b/SqlDummySeeder.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="35.5.0" />
-    <PackageReference Include="Dapper" Version="2.1.28" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
+    <PackageReference Include="Bogus" Version="35.6.3" />
+    <PackageReference Include="Dapper" Version="2.1.66" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- target .NET 9
- update package references for Bogus, Dapper and Microsoft.Data.SqlClient
- note .NET 9 requirement in README

## Testing
- `dotnet list package --outdated`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a9ebc0d554832a8e624ce7494fca74