### PR TITLE
Keep selected database enabled after load

### DIFF
--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -50,10 +50,6 @@
                 <div class="input-group">
                     <select asp-for="Connection.DatabaseName" id="dbSelect" class="form-select" disabled="@(string.IsNullOrEmpty(Model.Connection.DatabaseName) ? "" : null)">
                         <option value="">-- chọn database --</option>
-                        @if (!string.IsNullOrEmpty(Model.Connection.DatabaseName))
-                        {
-                            <option value="@Model.Connection.DatabaseName" selected>@Model.Connection.DatabaseName</option>
-                        }
                     </select>
                     <button class="btn btn-outline-secondary" type="button" id="btnLoadDb">Load</button>
                 </div>
@@ -211,7 +207,7 @@
     }
     rebuildDropdown();
 
-    async function loadDatabases(){
+    async function loadDatabases(selected){
         const body = {
             serverName: serverInput.value.trim(),
             databaseName: "", // ignored
@@ -249,14 +245,22 @@
             });
             dbSelect.disabled = false;
             dbHelp.textContent = 'Chọn một database.';
+            if (selected) {
+                dbSelect.value = selected;
+            }
         } catch (e){
             dbSelect.innerHTML = '<option value="">-- chọn database --</option>';
             dbHelp.textContent = 'Lỗi: ' + e;
         }
     }
 
-    btnLoad.addEventListener('click', loadDatabases);
+    btnLoad.addEventListener('click', () => loadDatabases());
     serverInput.addEventListener('blur', () => { if (serverInput.value.trim()) loadDatabases(); });
+
+    const initialDb = '@Model.Connection.DatabaseName';
+    if (serverInput.value.trim()) {
+        loadDatabases(initialDb);
+    }
 
     dbSelect.addEventListener('change', () => {
         if (dbSelect.value){


### PR DESCRIPTION
## Summary
- Allow database dropdown to stay enabled after selecting a database
- Show current database value when returning to the page

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f83a11dc832a8b5f01c1aca9d950