### PR TITLE
feat: apple-inspired UI theme

### DIFF
--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@ViewData["Title"] - SqlDummySeeder</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="~/css/apple-theme.css">
     <style>
         .stepper { display:flex; gap:8px; align-items:center; margin: 16px 0; }
         .step { padding:6px 12px; border-radius:999px; background:#eee; color:#333; }
@@ -15,7 +16,7 @@
         textarea.monospace { font-size: 0.9rem; }
     </style>
 </head>
-<body>
+<body class="apple-body">
     <div class="container py-3">
         <header class="mb-3 d-flex align-items-center gap-3">
             <h3 class="mb-0"><i class="bi bi-apple"></i> SQL Dummy Seeder</h3>

--- a/wwwroot/css/apple-theme.css
+++ b/wwwroot/css/apple-theme.css
@@ -1,0 +1,34 @@
+:root {
+  --apple-blue: #007aff;
+  --background-color: #f5f5f7;
+  --text-color: #1d1d1f;
+}
+
+body.apple-body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  background-color: var(--background-color);
+  color: var(--text-color);
+  animation: fadeIn 0.4s ease-out;
+}
+
+.card {
+  border-radius: 1rem;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+  animation: fadeIn 0.5s ease-out;
+}
+
+.btn-primary {
+  background-color: var(--apple-blue);
+  border-color: var(--apple-blue);
+  transition: background-color 0.3s ease;
+}
+
+.btn-primary:hover {
+  background-color: #0055d4;
+  border-color: #0055d4;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}


### PR DESCRIPTION
## Summary
- add Apple-like color palette, fonts and subtle fade-in animations
- apply new theme to shared layout

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a9fd05a4f4832a88620ec2250113a8