### PR TITLE
Align authentication field and widen table selection card

### DIFF
--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -16,7 +16,7 @@
 
     <form asp-action="Index" method="post" class="mt-3">
         <div class="row g-3">
-            <div class="col-md-6">
+            <div class="col-6">
                 <label class="form-label">Server Name</label>
                 <div class="input-group">
                     <input asp-for="Connection.ServerName" id="serverName" class="form-control" placeholder=".\\SQLEXPRESS hoặc 127.0.0.1" />
@@ -27,7 +27,7 @@
                 </div>
             </div>
 
-            <div class="col-md-6">
+            <div class="col-6">
                 <label class="form-label">Authentication</label>
                 <select asp-for="Connection.AuthMode" class="form-select" id="authMode">
                     <option value="Windows">Windows Authentication</option>
@@ -68,11 +68,10 @@
 
 @if (Model.Tables.Any())
 {
-<div id="tablesArea" class="row g-3 mt-4">
-  <div class="col-lg-7">
-    <div class="card">
-      <div class="card-body">
-        <h5 class="card-title">Chọn bảng để tạo dữ liệu</h5>
+<div id="tablesArea" class="mt-4">
+  <div class="card">
+    <div class="card-body">
+      <h5 class="card-title">Chọn bảng để tạo dữ liệu</h5>
         <div class="d-flex align-items-center gap-2 mb-2">
             <button class="btn btn-sm btn-outline-primary" type="button" id="btnSelectAll">Chọn tất cả</button>
             <button class="btn btn-sm btn-outline-secondary" type="button" id="btnClearAll">Bỏ chọn</button>
@@ -127,7 +126,6 @@
         </form>
       </div>
     </div>
-  </div>
 </div>
 
 <!-- Modal to show seeding result -->


### PR DESCRIPTION
## Summary
- Place Authentication dropdown on the same row as Server Name using equal column widths
- Make the "Chọn bảng để tạo dữ liệu" card span full width like the connection card

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68aabfa5bd24832aa60bb3e910e07300