### PR TITLE
Add Excel dummy templates module

### DIFF
--- a/Controllers/TemplatesController.cs
+++ b/Controllers/TemplatesController.cs
@@ -1,0 +1,141 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using SqlDummySeeder.Excel.Data;
+using SqlDummySeeder.Excel.Models;
+using SqlDummySeeder.Excel.Services;
+
+namespace SqlDummySeeder.Excel.Controllers;
+
+public class TemplatesController : Controller
+{
+    private readonly AppDbContext _db;
+    private readonly IExcelGenerator _excel;
+    public TemplatesController(AppDbContext db, IExcelGenerator excel)
+    {
+        _db = db;
+        _excel = excel;
+    }
+
+    public async Task<IActionResult> Index()
+    {
+        var items = await _db.Templates.Include(t => t.Columns.OrderBy(c => c.Order)).ToListAsync();
+        return View(items);
+    }
+
+    [HttpPost, ValidateAntiForgeryToken]
+    public async Task<IActionResult> Create(string name)
+    {
+        if (!string.IsNullOrWhiteSpace(name))
+        {
+            _db.Templates.Add(new Template { Name = name.Trim() });
+            await _db.SaveChangesAsync();
+        }
+        return RedirectToAction(nameof(Index));
+    }
+
+    public async Task<IActionResult> Edit(int id)
+    {
+        var template = await _db.Templates.FindAsync(id);
+        if (template is null) return NotFound();
+        ViewBag.Columns = await _db.Columns.Where(c => c.TemplateId == id).OrderBy(c => c.Order).ToListAsync();
+        return View(template);
+    }
+
+    [HttpPost, ValidateAntiForgeryToken]
+    public async Task<IActionResult> Edit(Template input)
+    {
+        var entity = await _db.Templates.FindAsync(input.Id);
+        if (entity is null) return NotFound();
+        entity.Name = input.Name;
+        await _db.SaveChangesAsync();
+        return RedirectToAction(nameof(Edit), new { id = entity.Id });
+    }
+
+    [HttpPost, ValidateAntiForgeryToken]
+    public async Task<IActionResult> AddColumn(int templateId, string name, ColumnValueMode mode)
+    {
+        var t = await _db.Templates.FindAsync(templateId);
+        if (t is null) return NotFound();
+
+        var nextOrder = await _db.Columns
+            .Where(x => x.TemplateId == templateId)
+            .Select(x => (int?)x.Order)
+            .MaxAsync() ?? 0;
+
+        _db.Columns.Add(new ColumnDefinition
+        {
+            TemplateId = templateId,
+            Name = name.Trim(),
+            Order = nextOrder + 1,
+            Mode = mode
+        });
+        await _db.SaveChangesAsync();
+        return RedirectToAction(nameof(Edit), new { id = templateId });
+    }
+
+    [HttpPost, ValidateAntiForgeryToken]
+    public async Task<IActionResult> Reorder(int templateId, [FromForm] int[] orderedIds)
+    {
+        var cols = await _db.Columns
+            .Where(c => c.TemplateId == templateId)
+            .OrderBy(c => c.Order)
+            .ToListAsync();
+
+        var orderMap = orderedIds
+            .Select((id, idx) => new { id, idx = idx + 1 })
+            .ToDictionary(x => x.id, x => x.idx);
+
+        foreach (var c in cols)
+        {
+            if (orderMap.TryGetValue(c.Id, out var newOrder))
+                c.Order = newOrder;
+        }
+        await _db.SaveChangesAsync();
+        return Ok(new { ok = true });
+    }
+
+    [HttpPost, ValidateAntiForgeryToken]
+    public async Task<IActionResult> SaveList(int id, string? listItemsRaw, bool? listPickRandom)
+    {
+        var col = await _db.Columns.FindAsync(id);
+        if (col is null) return NotFound();
+        col.ListItemsRaw = (listItemsRaw ?? string.Empty).Replace("\r\n", "\n");
+        col.ListPickRandom = listPickRandom == true;
+        await _db.SaveChangesAsync();
+        return RedirectToAction(nameof(Edit), new { id = col.TemplateId });
+    }
+
+    [HttpPost, ValidateAntiForgeryToken]
+    public async Task<IActionResult> SaveFormat(int id, string? formatString)
+    {
+        var col = await _db.Columns.FindAsync(id);
+        if (col is null) return NotFound();
+        col.FormatString = formatString;
+        await _db.SaveChangesAsync();
+        return RedirectToAction(nameof(Edit), new { id = col.TemplateId });
+    }
+
+    [HttpPost, ValidateAntiForgeryToken]
+    public async Task<IActionResult> DeleteColumn(int id)
+    {
+        var col = await _db.Columns.FindAsync(id);
+        if (col is null) return NotFound();
+        var tid = col.TemplateId;
+        _db.Columns.Remove(col);
+        await _db.SaveChangesAsync();
+        return RedirectToAction(nameof(Edit), new { id = tid });
+    }
+
+    public async Task<IActionResult> Export(int id, int rows = 100)
+    {
+        var template = await _db.Templates
+            .Include(t => t.Columns.OrderBy(c => c.Order))
+            .FirstOrDefaultAsync(t => t.Id == id);
+        if (template is null) return NotFound();
+
+        rows = Math.Clamp(rows, 1, 100000);
+        var content = await _excel.GenerateAsync(template, rows);
+        var fileName = $"{template.Name}-{rows}.xlsx";
+        return File(content, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", fileName);
+    }
+}

--- a/Excel/Data/AppDbContext.cs
+++ b/Excel/Data/AppDbContext.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore;
+using SqlDummySeeder.Excel.Models;
+
+namespace SqlDummySeeder.Excel.Data;
+
+public class AppDbContext : DbContext
+{
+    public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
+
+    public DbSet<Template> Templates => Set<Template>();
+    public DbSet<ColumnDefinition> Columns => Set<ColumnDefinition>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Template>(e =>
+        {
+            e.Property(x => x.Name).HasMaxLength(200).IsRequired();
+        });
+
+        modelBuilder.Entity<ColumnDefinition>(e =>
+        {
+            e.Property(x => x.Name).HasMaxLength(200).IsRequired();
+            e.Property(x => x.Mode).HasConversion<string>().IsRequired();
+            e.Property(x => x.ListItemsRaw).HasColumnType("TEXT");
+            e.Property(x => x.FormatString).HasMaxLength(4000);
+            e.HasOne(x => x.Template)
+                .WithMany(t => t.Columns)
+                .HasForeignKey(x => x.TemplateId)
+                .OnDelete(DeleteBehavior.Cascade);
+            e.HasIndex(x => new { x.TemplateId, x.Order }).IsUnique();
+        });
+    }
+}

--- a/Excel/Models/ColumnDefinition.cs
+++ b/Excel/Models/ColumnDefinition.cs
@@ -1,0 +1,30 @@
+namespace SqlDummySeeder.Excel.Models;
+
+public enum ColumnValueMode
+{
+    FromList = 0,
+    FormatString = 1
+}
+
+public class ColumnDefinition
+{
+    public int Id { get; set; }
+    public int TemplateId { get; set; }
+    public Template? Template { get; set; }
+
+    public int Order { get; set; }
+    public string Name { get; set; } = "";
+    public ColumnValueMode Mode { get; set; }
+
+    public string? ListItemsRaw { get; set; }
+    public bool ListPickRandom { get; set; } = false;
+
+    public string? FormatString { get; set; }
+
+    public IEnumerable<string> AsListItems() =>
+        string.IsNullOrWhiteSpace(ListItemsRaw)
+            ? Enumerable.Empty<string>()
+            : ListItemsRaw!
+                .Replace("\r\n", "\n")
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+}

--- a/Excel/Models/Template.cs
+++ b/Excel/Models/Template.cs
@@ -1,0 +1,9 @@
+namespace SqlDummySeeder.Excel.Models;
+
+public class Template
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = "";
+
+    public ICollection<ColumnDefinition> Columns { get; set; } = new List<ColumnDefinition>();
+}

--- a/Excel/Models/TemplateEditViewModel.cs
+++ b/Excel/Models/TemplateEditViewModel.cs
@@ -1,0 +1,18 @@
+namespace SqlDummySeeder.Excel.Models;
+
+public class TemplateEditViewModel
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = "";
+    public List<ColumnEditViewModel> Columns { get; set; } = new();
+}
+
+public class ColumnEditViewModel
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = "";
+    public ColumnValueMode Mode { get; set; }
+    public string? ListItemsRaw { get; set; }
+    public bool ListPickRandom { get; set; }
+    public string? FormatString { get; set; }
+}

--- a/Excel/Services/ExcelGenerator.cs
+++ b/Excel/Services/ExcelGenerator.cs
@@ -1,0 +1,102 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+using ClosedXML.Excel;
+using SqlDummySeeder.Excel.Models;
+
+namespace SqlDummySeeder.Excel.Services;
+
+public class ExcelGenerator : IExcelGenerator
+{
+    public Task<byte[]> GenerateAsync(Template template, int rows)
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Data");
+
+        var orderedCols = template.Columns.OrderBy(x => x.Order).ToList();
+
+        for (int c = 0; c < orderedCols.Count; c++)
+        {
+            ws.Cell(1, c + 1).Value = orderedCols[c].Name;
+            ws.Cell(1, c + 1).Style.Font.Bold = true;
+        }
+
+        var rnd = new Random();
+
+        for (int r = 0; r < rows; r++)
+        {
+            int excelRow = r + 2;
+            for (int c = 0; c < orderedCols.Count; c++)
+            {
+                var col = orderedCols[c];
+                string value = col.Mode switch
+                {
+                    ColumnValueMode.FromList => ValueFromList(col, r, rnd),
+                    ColumnValueMode.FormatString => ValueFromFormat(col.FormatString ?? "", r, rnd),
+                    _ => ""
+                };
+                ws.Cell(excelRow, c + 1).Value = value;
+            }
+        }
+
+        using var ms = new MemoryStream();
+        wb.SaveAs(ms);
+        return Task.FromResult(ms.ToArray());
+    }
+
+    private static string ValueFromList(ColumnDefinition col, int rowIndex, Random rnd)
+    {
+        var items = col.AsListItems().ToList();
+        if (items.Count == 0) return string.Empty;
+        if (col.ListPickRandom)
+        {
+            return items[rnd.Next(items.Count)];
+        }
+        else
+        {
+            return items[rowIndex % items.Count];
+        }
+    }
+
+    private static string ValueFromFormat(string format, int rowIndex, Random rnd)
+    {
+        string s = format;
+
+        s = Regex.Replace(s, @"\{i(?::([^}]+))?\}", m =>
+        {
+            var idx = rowIndex + 1;
+            var fmt = m.Groups[1].Success ? m.Groups[1].Value : null;
+            return fmt is null ? idx.ToString() : idx.ToString(fmt, CultureInfo.InvariantCulture);
+        });
+
+        s = s.Replace("{guid}", Guid.NewGuid().ToString());
+
+        s = Regex.Replace(s, @"\{date:(?<fmt>[^}]+)\}", m =>
+        {
+            var fmt = m.Groups["fmt"].Value;
+            return DateTime.Today.ToString(fmt, CultureInfo.InvariantCulture);
+        });
+
+        s = Regex.Replace(s, @"\{now:(?<fmt>[^}]+)\}", m =>
+        {
+            var fmt = m.Groups["fmt"].Value;
+            return DateTime.Now.ToString(fmt, CultureInfo.InvariantCulture);
+        });
+
+        s = Regex.Replace(s, @"\{rand:(?<min>-?\d+)-(?<max>-?\d+)\}", m =>
+        {
+            int min = int.Parse(m.Groups["min"].Value);
+            int max = int.Parse(m.Groups["max"].Value);
+            if (min > max) (min, max) = (max, min);
+            return rnd.Next(min, max + 1).ToString(CultureInfo.InvariantCulture);
+        });
+
+        s = Regex.Replace(s, @"\{pick:(?<opts>[^}]+)\}", m =>
+        {
+            var opts = m.Groups["opts"].Value.Split('|', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (opts.Length == 0) return "";
+            return opts[rnd.Next(opts.Length)];
+        });
+
+        return s;
+    }
+}

--- a/Excel/Services/IExcelGenerator.cs
+++ b/Excel/Services/IExcelGenerator.cs
@@ -1,0 +1,8 @@
+using SqlDummySeeder.Excel.Models;
+
+namespace SqlDummySeeder.Excel.Services;
+
+public interface IExcelGenerator
+{
+    Task<byte[]> GenerateAsync(Template template, int rows);
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,7 +1,10 @@
 using Microsoft.AspNetCore.Builder;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using SqlDummySeeder.Services;
+using SqlDummySeeder.Excel.Data;
+using SqlDummySeeder.Excel.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -12,7 +15,17 @@ builder.Services.AddSingleton<SavedConnectionsService>();
 builder.Services.AddScoped<SqlMetadataService>();
 builder.Services.AddScoped<DummyDataService>();
 
+builder.Services.AddDbContext<AppDbContext>(options =>
+    options.UseSqlite("Data Source=excelDummy.db"));
+builder.Services.AddScoped<IExcelGenerator, ExcelGenerator>();
+
 var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+    db.Database.EnsureCreated();
+}
 
 if (!app.Environment.IsDevelopment())
 {

--- a/SqlDummySeeder.csproj
+++ b/SqlDummySeeder.csproj
@@ -8,6 +8,8 @@
     <PackageReference Include="Bogus" Version="35.6.3" />
     <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0" />
+    <PackageReference Include="ClosedXML" Version="0.102.2" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="wwwroot\css\" />

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -241,9 +241,10 @@
     <header class="header">
         <div class="wrap">
             <div class="brand"><a style="color: #111; text-decoration:none;" href="/">Data Dummy</a></div>
-            <nav class="nav">
+           <nav class="nav">
                 <a class="btn" href="/">SQL Dummy</a>
-            </nav>
+                <a class="btn" href="/Templates">Excel Dummy</a>
+           </nav>
         </div>
     </header>
     <main class="main">

--- a/Views/Templates/Edit.cshtml
+++ b/Views/Templates/Edit.cshtml
@@ -1,0 +1,158 @@
+@model SqlDummySeeder.Excel.Models.Template
+@{
+    ViewData["Title"] = "Edit Template";
+    var columns = (IEnumerable<SqlDummySeeder.Excel.Models.ColumnDefinition>)ViewBag.Columns;
+}
+<div class="card card-pad mb-3">
+    <div class="d-flex justify-content-between align-items-center mb-2">
+        <h4 class="m-0">Edit: @Model.Name</h4>
+        <a class="btn-small" asp-action="Index">Back</a>
+    </div>
+
+    <form class="form-inline" asp-action="Edit" method="post">
+        @Html.AntiForgeryToken()
+        <input type="hidden" asp-for="Id" />
+        <input asp-for="Name" placeholder="Template name" />
+        <button type="submit" class="btn-small btn-ok-soft">Save name</button>
+    </form>
+</div>
+
+<div class="card card-pad">
+    <h5 class="mb-3">Columns</h5>
+
+    <form class="form-inline mb-3" asp-action="AddColumn" method="post">
+        @Html.AntiForgeryToken()
+        <input type="hidden" name="TemplateId" value="@Model.Id" />
+        <input type="text" name="Name" placeholder="Column name" required />
+        <select name="Mode">
+            <option value="FromList">FromList</option>
+            <option value="FormatString">FormatString</option>
+        </select>
+        <button type="submit" class="btn-small btn-ok-soft">Add Column</button>
+    </form>
+
+    <div class="table-responsive table-fixed">
+        <form id="reorderForm" method="post" asp-action="Reorder">
+            @Html.AntiForgeryToken()
+            <input type="hidden" name="templateId" value="@Model.Id" />
+            <table class="table align-middle">
+                <thead>
+                    <tr>
+                        <th style="width:42px;"></th>
+                        <th style="min-width:180px;">Name</th>
+                        <th style="min-width:140px;">Mode</th>
+                        <th>Config</th>
+                        <th style="min-width:100px;"></th>
+                    </tr>
+                </thead>
+                <tbody id="cols">
+                    @foreach (var c in columns.OrderBy(c => c.Order))
+                    {
+                        <tr data-id="@c.Id">
+                            <td><span class="drag-handle" title="Drag to reorder">☰</span></td>
+                            <td>@c.Name</td>
+                            <td>@c.Mode</td>
+                            <td>
+                                @if (c.Mode == SqlDummySeeder.Excel.Models.ColumnValueMode.FromList)
+                                {
+                                    <form asp-action="SaveList" method="post" class="d-grid gap-2">
+                                        @Html.AntiForgeryToken()
+                                        <input type="hidden" name="Id" value="@c.Id" />
+                                        <label class="help">Items (mỗi dòng 1 giá trị)</label>
+                                        <textarea class="monospace" name="listItemsRaw" rows="4">@c.ListItemsRaw</textarea>
+                                        <label class="help">
+                                            <input type="checkbox" name="listPickRandom" value="true" @(c.ListPickRandom ? "checked" : "") />
+                                            Pick random
+                                        </label>
+                                        <div><button type="submit" class="btn-small btn-ok-soft">Save</button></div>
+                                    </form>
+                                }
+                                else
+                                {
+                                    <form asp-action="SaveFormat" method="post" class="d-grid gap-2">
+                                        @Html.AntiForgeryToken()
+                                        <input type="hidden" name="Id" value="@c.Id" />
+                                        <label class="help">Format String</label>
+                                        <input type="text" name="formatString" value="@c.FormatString" />
+                                        <div class="help">
+                                            Tokens:
+                                            <code>{i}</code>, <code>{i:000}</code>, <code>{guid}</code>,
+                                            <code>{date:yyyy-MM-dd}</code>, <code>{now:HHmmss}</code>,
+                                            <code>{rand:100-999}</code>, <code>{pick:A|B|C}</code>
+                                        </div>
+                                        <div><button type="submit" class="btn-small btn-ok-soft">Save</button></div>
+                                    </form>
+                                }
+                            </td>
+                            <td>
+                                <form asp-action="DeleteColumn" method="post" onsubmit="return confirm('Delete column?')">
+                                    @Html.AntiForgeryToken()
+                                    <input type="hidden" name="Id" value="@c.Id" />
+                                    <button type="submit" class="btn-small btn-danger-soft">Delete</button>
+                                </form>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </form>
+    </div>
+
+    <div class="mt-3">
+        <a class="btn-small btn-warn-soft" asp-action="Export" asp-route-id="@Model.Id" asp-route-rows="100">Export 100 rows</a>
+    </div>
+</div>
+
+@section Scripts {
+    <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>
+    <script>
+        (function() {
+          const tbody = document.getElementById('cols');
+          const form  = document.getElementById('reorderForm');
+          if (!tbody || !form) return;
+
+          new Sortable(tbody, {
+            handle: '.drag-handle',
+            animation: 150,
+            onEnd: () => {
+              const ids = Array.from(tbody.querySelectorAll('tr[data-id]'))
+                           .map(tr => tr.getAttribute('data-id'));
+
+              // xóa input cũ
+              [...form.querySelectorAll('input[name="orderedIds"]')].forEach(e => e.remove());
+              // thêm input theo thứ tự mới
+              ids.forEach(id => {
+                const i = document.createElement('input');
+                i.type = 'hidden';
+                i.name = 'orderedIds';
+                i.value = id;
+                form.appendChild(i);
+              });
+
+              // submit bằng fetch để không reload trang
+              const data = new FormData(form);
+              fetch('@Url.Action("Reorder", "Templates")', {
+                method: 'POST',
+                body: data
+              }).catch(console.error);
+            }
+          });
+        })();
+    </script>
+    <style>
+        .drag-handle {
+            cursor: grab;
+            user-select: none;
+            font-size: 18px;
+            padding: 6px 10px;
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            background: #fff;
+            box-shadow: var(--shadow)
+        }
+
+            .drag-handle:active {
+                cursor: grabbing
+            }
+    </style>
+}

--- a/Views/Templates/Edit.cshtml
+++ b/Views/Templates/Edit.cshtml
@@ -1,40 +1,35 @@
-@model SqlDummySeeder.Excel.Models.Template
+@model SqlDummySeeder.Excel.Models.TemplateEditViewModel
 @{
     ViewData["Title"] = "Edit Template";
-    var columns = (IEnumerable<SqlDummySeeder.Excel.Models.ColumnDefinition>)ViewBag.Columns;
 }
-<div class="card card-pad mb-3">
-    <div class="d-flex justify-content-between align-items-center mb-2">
-        <h4 class="m-0">Edit: @Model.Name</h4>
-        <a class="btn-small" asp-action="Index">Back</a>
+<form asp-action="Edit" method="post" id="editForm">
+    @Html.AntiForgeryToken()
+    <input type="hidden" asp-for="Id" />
+    <div class="card card-pad mb-3">
+        <div class="d-flex justify-content-between align-items-center mb-2">
+            <h4 class="m-0">Edit: @Model.Name</h4>
+            <a class="btn-small" asp-action="Index">Back</a>
+        </div>
+        <input asp-for="Name" placeholder="Template name" />
+        <div class="mt-2">
+            <button type="submit" class="btn-small btn-ok-soft">Save</button>
+        </div>
     </div>
 
-    <form class="form-inline" asp-action="Edit" method="post">
-        @Html.AntiForgeryToken()
-        <input type="hidden" asp-for="Id" />
-        <input asp-for="Name" placeholder="Template name" />
-        <button type="submit" class="btn-small btn-ok-soft">Save name</button>
-    </form>
-</div>
+    <div class="card card-pad">
+        <h5 class="mb-3">Columns</h5>
 
-<div class="card card-pad">
-    <h5 class="mb-3">Columns</h5>
-
-    <form class="form-inline mb-3" asp-action="AddColumn" method="post">
-        @Html.AntiForgeryToken()
-        <input type="hidden" name="TemplateId" value="@Model.Id" />
-        <input type="text" name="Name" placeholder="Column name" required />
-        <select name="Mode">
-            <option value="FromList">FromList</option>
-            <option value="FormatString">FormatString</option>
-        </select>
-        <button type="submit" class="btn-small btn-ok-soft">Add Column</button>
-    </form>
-
-    <div class="table-responsive table-fixed">
-        <form id="reorderForm" method="post" asp-action="Reorder">
-            @Html.AntiForgeryToken()
+        <div class="form-inline mb-3">
             <input type="hidden" name="templateId" value="@Model.Id" />
+            <input type="text" name="name" placeholder="Column name" />
+            <select name="mode">
+                <option value="FromList">FromList</option>
+                <option value="FormatString">FormatString</option>
+            </select>
+            <button type="submit" formaction="@Url.Action("AddColumn")" formmethod="post" formnovalidate class="btn-small btn-ok-soft">Add Column</button>
+        </div>
+
+        <div class="table-responsive table-fixed">
             <table class="table align-middle">
                 <thead>
                     <tr>
@@ -46,97 +41,77 @@
                     </tr>
                 </thead>
                 <tbody id="cols">
-                    @foreach (var c in columns.OrderBy(c => c.Order))
-                    {
-                        <tr data-id="@c.Id">
-                            <td><span class="drag-handle" title="Drag to reorder">☰</span></td>
-                            <td>@c.Name</td>
-                            <td>@c.Mode</td>
-                            <td>
-                                @if (c.Mode == SqlDummySeeder.Excel.Models.ColumnValueMode.FromList)
-                                {
-                                    <form asp-action="SaveList" method="post" class="d-grid gap-2">
-                                        @Html.AntiForgeryToken()
-                                        <input type="hidden" name="Id" value="@c.Id" />
-                                        <label class="help">Items (mỗi dòng 1 giá trị)</label>
-                                        <textarea class="monospace" name="listItemsRaw" rows="4">@c.ListItemsRaw</textarea>
-                                        <label class="help">
-                                            <input type="checkbox" name="listPickRandom" value="true" @(c.ListPickRandom ? "checked" : "") />
-                                            Pick random
-                                        </label>
-                                        <div><button type="submit" class="btn-small btn-ok-soft">Save</button></div>
-                                    </form>
-                                }
-                                else
-                                {
-                                    <form asp-action="SaveFormat" method="post" class="d-grid gap-2">
-                                        @Html.AntiForgeryToken()
-                                        <input type="hidden" name="Id" value="@c.Id" />
-                                        <label class="help">Format String</label>
-                                        <input type="text" name="formatString" value="@c.FormatString" />
-                                        <div class="help">
-                                            Tokens:
-                                            <code>{i}</code>, <code>{i:000}</code>, <code>{guid}</code>,
-                                            <code>{date:yyyy-MM-dd}</code>, <code>{now:HHmmss}</code>,
-                                            <code>{rand:100-999}</code>, <code>{pick:A|B|C}</code>
-                                        </div>
-                                        <div><button type="submit" class="btn-small btn-ok-soft">Save</button></div>
-                                    </form>
-                                }
-                            </td>
-                            <td>
-                                <form asp-action="DeleteColumn" method="post" onsubmit="return confirm('Delete column?')">
-                                    @Html.AntiForgeryToken()
-                                    <input type="hidden" name="Id" value="@c.Id" />
-                                    <button type="submit" class="btn-small btn-danger-soft">Delete</button>
-                                </form>
-                            </td>
-                        </tr>
-                    }
+@for (int i = 0; i < Model.Columns.Count; i++)
+{
+    var c = Model.Columns[i];
+    <tr data-id="@c.Id">
+        <td><span class="drag-handle" title="Drag to reorder">☰</span></td>
+        <td>@c.Name</td>
+        <td>@c.Mode</td>
+        <td>
+            <input type="hidden" name="Columns[@i].Id" value="@c.Id" />
+            @if (c.Mode == SqlDummySeeder.Excel.Models.ColumnValueMode.FromList)
+            {
+                <label class="help">Items (mỗi dòng 1 giá trị)</label>
+                <textarea class="monospace" name="Columns[@i].ListItemsRaw" rows="4">@c.ListItemsRaw</textarea>
+                <input type="hidden" name="Columns[@i].ListPickRandom" value="false" />
+                <label class="help">
+                    <input type="checkbox" name="Columns[@i].ListPickRandom" value="true" @(c.ListPickRandom ? "checked" : "") />
+                    Pick random
+                </label>
+                <input type="hidden" name="Columns[@i].FormatString" value="@c.FormatString" />
+            }
+            else
+            {
+                <label class="help">Format String</label>
+                <input type="text" name="Columns[@i].FormatString" value="@c.FormatString" />
+                <div class="help">
+                    Tokens:
+                    <code>{i}</code>, <code>{i:000}</code>, <code>{guid}</code>,
+                    <code>{date:yyyy-MM-dd}</code>, <code>{now:HHmmss}</code>,
+                    <code>{rand:100-999}</code>, <code>{pick:A|B|C}</code>
+                </div>
+                <input type="hidden" name="Columns[@i].ListItemsRaw" value="@c.ListItemsRaw" />
+                <input type="hidden" name="Columns[@i].ListPickRandom" value="@c.ListPickRandom" />
+            }
+        </td>
+        <td>
+            <button type="submit" formaction="@Url.Action("DeleteColumn")" formmethod="post" formnovalidate class="btn-small btn-danger-soft" name="id" value="@c.Id" onclick="return confirm('Delete column?')">Delete</button>
+        </td>
+    </tr>
+}
                 </tbody>
             </table>
-        </form>
-    </div>
+        </div>
 
-    <div class="mt-3">
-        <a class="btn-small btn-warn-soft" asp-action="Export" asp-route-id="@Model.Id" asp-route-rows="100">Export 100 rows</a>
+        <div class="mt-3">
+            <a class="btn-small btn-warn-soft" asp-action="Export" asp-route-id="@Model.Id" asp-route-rows="100">Export 100 rows</a>
+        </div>
     </div>
-</div>
+</form>
 
 @section Scripts {
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>
     <script>
-        (function() {
-          const tbody = document.getElementById('cols');
-          const form  = document.getElementById('reorderForm');
-          if (!tbody || !form) return;
+        (function () {
+            const tbody = document.getElementById('cols');
+            const idInput = document.getElementById('Id');
+            if (!tbody || !idInput) return;
 
-          new Sortable(tbody, {
-            handle: '.drag-handle',
-            animation: 150,
-            onEnd: () => {
-              const ids = Array.from(tbody.querySelectorAll('tr[data-id]'))
-                           .map(tr => tr.getAttribute('data-id'));
-
-              // xóa input cũ
-              [...form.querySelectorAll('input[name="orderedIds"]')].forEach(e => e.remove());
-              // thêm input theo thứ tự mới
-              ids.forEach(id => {
-                const i = document.createElement('input');
-                i.type = 'hidden';
-                i.name = 'orderedIds';
-                i.value = id;
-                form.appendChild(i);
-              });
-
-              // submit bằng fetch để không reload trang
-              const data = new FormData(form);
-              fetch('@Url.Action("Reorder", "Templates")', {
-                method: 'POST',
-                body: data
-              }).catch(console.error);
-            }
-          });
+            new Sortable(tbody, {
+                handle: '.drag-handle',
+                animation: 150,
+                onEnd: () => {
+                    const ids = Array.from(tbody.querySelectorAll('tr[data-id]')).map(tr => tr.getAttribute('data-id'));
+                    const data = new FormData();
+                    data.append('templateId', idInput.value);
+                    ids.forEach(id => data.append('orderedIds', id));
+                    fetch('@Url.Action("Reorder", "Templates")', {
+                        method: 'POST',
+                        body: data
+                    }).catch(console.error);
+                }
+            });
         })();
     </script>
     <style>

--- a/Views/Templates/Edit.cshtml
+++ b/Views/Templates/Edit.cshtml
@@ -106,9 +106,14 @@
                     const data = new FormData();
                     data.append('templateId', idInput.value);
                     ids.forEach(id => data.append('orderedIds', id));
+                    const tokenInput = document.querySelector('input[name="__RequestVerificationToken"]');
+                    if (tokenInput) {
+                        data.append('__RequestVerificationToken', tokenInput.value);
+                    }
                     fetch('@Url.Action("Reorder", "Templates")', {
                         method: 'POST',
-                        body: data
+                        body: data,
+                        credentials: 'same-origin'
                     }).catch(console.error);
                 }
             });

--- a/Views/Templates/Index.cshtml
+++ b/Views/Templates/Index.cshtml
@@ -1,0 +1,34 @@
+@model IEnumerable<SqlDummySeeder.Excel.Models.Template>
+@{
+    ViewData["Title"] = "Templates";
+}
+<div class="card card-pad">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h4 class="m-0">Templates</h4>
+        <span class="badge-soft">@Model.Count() total</span>
+    </div>
+
+    <form class="form-inline mb-3" asp-action="Create" method="post">
+        <input type="text" name="name" placeholder="New template name..." required />
+        <button type="submit" class="btn-small btn-ok-soft">Add</button>
+    </form>
+
+    <div class="table-responsive table-fixed">
+        <table class="table">
+            <thead><tr><th>Name</th><th>Columns</th><th>Actions</th></tr></thead>
+            <tbody>
+@foreach (var t in Model)
+{
+    <tr>
+        <td>@t.Name</td>
+        <td>@t.Columns.Count</td>
+        <td class="d-flex gap-2">
+            <a class="btn-small" asp-action="Edit" asp-route-id="@t.Id">Edit</a>
+            <a class="btn-small btn-warn-soft" asp-action="Export" asp-route-id="@t.Id" asp-route-rows="100">Export 100</a>
+        </td>
+    </tr>
+}
+            </tbody>
+        </table>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- integrate Excel dummy generator with EF Core and ClosedXML
- add templates controller and views for managing Excel templates
- update layout to navigate between SQL and Excel dummy tools

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe937b574832a89cdf11a4893dcb4