### PR TITLE
feat: add template creation modal

### DIFF
--- a/Views/Templates/Index.cshtml
+++ b/Views/Templates/Index.cshtml
@@ -4,16 +4,18 @@
 }
 <div class="card card-pad">
     <div class="d-flex justify-content-between align-items-center mb-3">
-        <h4 class="m-0">Templates</h4>
-        <span class="badge-soft">@Model.Count() total</span>
+        <div class="d-flex align-items-center gap-2">
+            <h4 class="m-0">Templates</h4>
+            <span class="badge-soft">@Model.Count() total</span>
+        </div>
+        <button id="addBtn" class="btn-small btn-ok-soft">Add</button>
     </div>
-    <button id="addBtn" class="btn-small btn-ok-soft mb-3">Add</button>
-
-    <dialog id="addDialog">
+    <dialog id="addDialog" class="card card-pad">
+        <h5 class="mb-3">Add Template</h5>
         <form id="templateForm" method="post" enctype="multipart/form-data">
             <div class="mb-2">
-                <label><input type="radio" name="mode" value="new" id="mode-new" checked /> New</label>
-                <label class="ms-2"><input type="radio" name="mode" value="import" id="mode-import" /> Import</label>
+                <label class="d-inline-flex align-items-center me-3 mb-0"><input type="radio" name="mode" value="new" id="mode-new" checked class="me-1" /> New</label>
+                <label class="d-inline-flex align-items-center mb-0"><input type="radio" name="mode" value="import" id="mode-import" class="me-1" /> Import</label>
             </div>
             <div id="name-group" class="mb-2">
                 <input type="text" name="name" placeholder="Template name" required />

--- a/Views/Templates/Index.cshtml
+++ b/Views/Templates/Index.cshtml
@@ -10,25 +10,27 @@
         </div>
         <button id="addBtn" class="btn-small btn-ok-soft">Add</button>
     </div>
-    <dialog id="addDialog" class="card card-pad">
-        <h5 class="mb-3">Add Template</h5>
-        <form id="templateForm" method="post" enctype="multipart/form-data">
-            <div class="mb-2">
-                <label class="d-inline-flex align-items-center me-3 mb-0"><input type="radio" name="mode" value="new" id="mode-new" checked class="me-1" /> New</label>
-                <label class="d-inline-flex align-items-center mb-0"><input type="radio" name="mode" value="import" id="mode-import" class="me-1" /> Import</label>
-            </div>
-            <div id="name-group" class="mb-2">
-                <input type="text" name="name" placeholder="Template name" required />
-            </div>
-            <div id="file-group" class="mb-2" style="display:none;">
-                <input type="file" name="file" accept=".xlsx,.xls" />
-            </div>
-            <div class="d-flex gap-2 justify-content-end">
-                <button type="submit" class="btn-small btn-ok-soft">Create</button>
-                <button type="button" class="btn-small" id="cancelBtn">Cancel</button>
-            </div>
-        </form>
-    </dialog>
+    <div id="addDialog" class="modal-overlay">
+        <div class="card card-pad modal-card">
+            <h5 class="mb-3">Add Template</h5>
+            <form id="templateForm" method="post" enctype="multipart/form-data">
+                <div class="mb-2">
+                    <label class="d-inline-flex align-items-center me-3 mb-0"><input type="radio" name="mode" value="new" id="mode-new" checked class="me-1" /> New</label>
+                    <label class="d-inline-flex align-items-center mb-0"><input type="radio" name="mode" value="import" id="mode-import" class="me-1" /> Import</label>
+                </div>
+                <div id="name-group" class="mb-2">
+                    <input type="text" name="name" placeholder="Template name" required />
+                </div>
+                <div id="file-group" class="mb-2" style="display:none;">
+                    <input type="file" name="file" accept=".xlsx,.xls" />
+                </div>
+                <div class="d-flex gap-2 justify-content-end">
+                    <button type="submit" class="btn-small btn-ok-soft">Create</button>
+                    <button type="button" class="btn-small" id="cancelBtn">Cancel</button>
+                </div>
+            </form>
+        </div>
+    </div>
 
     <div class="table-responsive table-fixed">
         <table class="table">
@@ -90,11 +92,11 @@
         addBtn.addEventListener('click', () => {
             newRadio.checked = true;
             updateDialog();
-            dialog.showModal();
+            dialog.classList.add('show');
         });
 
         newRadio.addEventListener('change', updateDialog);
         importRadio.addEventListener('change', updateDialog);
-        cancelBtn.addEventListener('click', () => dialog.close());
+        cancelBtn.addEventListener('click', () => dialog.classList.remove('show'));
     </script>
 }

--- a/Views/Templates/Index.cshtml
+++ b/Views/Templates/Index.cshtml
@@ -7,16 +7,26 @@
         <h4 class="m-0">Templates</h4>
         <span class="badge-soft">@Model.Count() total</span>
     </div>
+    <button id="addBtn" class="btn-small btn-ok-soft mb-3">Add</button>
 
-    <form class="form-inline mb-3" asp-action="Create" method="post">
-        <input type="text" name="name" placeholder="New template name..." required />
-        <button type="submit" class="btn-small btn-ok-soft">Add</button>
-    </form>
-
-    <form class="form-inline mb-3" asp-action="Import" method="post" enctype="multipart/form-data">
-        <input type="file" name="file" accept=".xlsx,.xls" required />
-        <button type="submit" class="btn-small btn-ok-soft">Import</button>
-    </form>
+    <dialog id="addDialog">
+        <form id="templateForm" method="post" enctype="multipart/form-data">
+            <div class="mb-2">
+                <label><input type="radio" name="mode" value="new" id="mode-new" checked /> New</label>
+                <label class="ms-2"><input type="radio" name="mode" value="import" id="mode-import" /> Import</label>
+            </div>
+            <div id="name-group" class="mb-2">
+                <input type="text" name="name" placeholder="Template name" required />
+            </div>
+            <div id="file-group" class="mb-2" style="display:none;">
+                <input type="file" name="file" accept=".xlsx,.xls" />
+            </div>
+            <div class="d-flex gap-2 justify-content-end">
+                <button type="submit" class="btn-small btn-ok-soft">Create</button>
+                <button type="button" class="btn-small" id="cancelBtn">Cancel</button>
+            </div>
+        </form>
+    </dialog>
 
     <div class="table-responsive table-fixed">
         <table class="table">
@@ -49,5 +59,40 @@
                 }
             });
         });
+
+        const addBtn = document.getElementById('addBtn');
+        const dialog = document.getElementById('addDialog');
+        const newRadio = document.getElementById('mode-new');
+        const importRadio = document.getElementById('mode-import');
+        const nameGroup = document.getElementById('name-group');
+        const fileGroup = document.getElementById('file-group');
+        const form = document.getElementById('templateForm');
+        const cancelBtn = document.getElementById('cancelBtn');
+
+        function updateDialog() {
+            if (newRadio.checked) {
+                nameGroup.style.display = '';
+                fileGroup.style.display = 'none';
+                form.action = '@Url.Action("Create")';
+                form.querySelector('input[name="name"]').required = true;
+                form.querySelector('input[name="file"]').required = false;
+            } else {
+                nameGroup.style.display = 'none';
+                fileGroup.style.display = '';
+                form.action = '@Url.Action("Import")';
+                form.querySelector('input[name="name"]').required = false;
+                form.querySelector('input[name="file"]').required = true;
+            }
+        }
+
+        addBtn.addEventListener('click', () => {
+            newRadio.checked = true;
+            updateDialog();
+            dialog.showModal();
+        });
+
+        newRadio.addEventListener('change', updateDialog);
+        importRadio.addEventListener('change', updateDialog);
+        cancelBtn.addEventListener('click', () => dialog.close());
     </script>
 }

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -37,3 +37,22 @@ hr.div {
     border-top: 1px solid var(--border);
     margin: 16px 0;
 }
+
+.modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.3);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.modal-overlay.show {
+    display: flex;
+}
+
+.modal-card {
+    width: 320px;
+    max-width: 90vw;
+}


### PR DESCRIPTION
## Summary
- add modal for creating/importing templates with radio toggle
- default to new template name input, or import file option
- hook up JS to swap form action and required fields

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bc076bb4c4832a9763d8630c059aaa