### PR TITLE
Streamline template editing UI

### DIFF
--- a/Views/Templates/Edit.cshtml
+++ b/Views/Templates/Edit.cshtml
@@ -21,8 +21,8 @@
                     <option value="FromList">FromList</option>
                     <option value="FormatString">FormatString</option>
                 </select>
+                <button type="submit" formaction="@Url.Action("AddColumn")" formmethod="post" formnovalidate class="btn-small btn-ok-soft">Add Column</button>
             </div>
-            <button type="submit" formaction="@Url.Action("AddColumn")" formmethod="post" formnovalidate class="btn-small btn-ok-soft ms-2">Add Column</button>
         </div>
 
         <div class="table-responsive table-fixed">
@@ -54,7 +54,7 @@
             <input type="hidden" name="Columns[@i].Id" value="@c.Id" />
             <div class="config-fromlist" style="display:@(c.Mode == SqlDummySeeder.Excel.Models.ColumnValueMode.FromList ? "block" : "none")">
                 <label class="help">Items (mỗi dòng 1 giá trị)</label>
-                <textarea class="monospace" name="Columns[@i].ListItemsRaw" rows="4" @(c.Mode == SqlDummySeeder.Excel.Models.ColumnValueMode.FromList ? "" : "disabled")>@c.ListItemsRaw</textarea>
+                <textarea class="monospace form-control w-100" name="Columns[@i].ListItemsRaw" rows="4" @(c.Mode == SqlDummySeeder.Excel.Models.ColumnValueMode.FromList ? "" : "disabled")>@c.ListItemsRaw</textarea>
                 <label class="help">
                     <input type="checkbox" name="Columns[@i].ListPickRandom" value="true" @(c.ListPickRandom ? "checked" : "") @(c.Mode == SqlDummySeeder.Excel.Models.ColumnValueMode.FromList ? "" : "disabled") />
                     Pick random
@@ -63,7 +63,7 @@
             </div>
             <div class="config-formatstring" style="display:@(c.Mode == SqlDummySeeder.Excel.Models.ColumnValueMode.FormatString ? "block" : "none")">
                 <label class="help">Format String</label>
-                <input type="text" name="Columns[@i].FormatString" value="@c.FormatString" @(c.Mode == SqlDummySeeder.Excel.Models.ColumnValueMode.FormatString ? "" : "disabled") />
+                <input type="text" class="form-control w-100" name="Columns[@i].FormatString" value="@c.FormatString" @(c.Mode == SqlDummySeeder.Excel.Models.ColumnValueMode.FormatString ? "" : "disabled") />
                 <div class="help">
                     Tokens:
                     <code>{i}</code>, <code>{i:000}</code>, <code>{guid}</code>,

--- a/Views/Templates/Edit.cshtml
+++ b/Views/Templates/Edit.cshtml
@@ -5,18 +5,15 @@
 <form asp-action="Edit" method="post" id="editForm">
     @Html.AntiForgeryToken()
     <input type="hidden" asp-for="Id" />
-    <div class="card card-pad mb-3">
+    <div class="card card-pad">
         <div class="d-flex justify-content-between align-items-center mb-2">
             <h4 class="m-0">Edit: @Model.Name</h4>
             <a class="btn-small" asp-action="Index">Back</a>
         </div>
         <input asp-for="Name" placeholder="Template name" />
-        <div class="mt-2">
+        <div class="mt-2 mb-4">
             <button type="submit" class="btn-small btn-ok-soft">Save</button>
         </div>
-    </div>
-
-    <div class="card card-pad">
         <h5 class="mb-3">Columns</h5>
 
         <div class="form-inline mb-3">

--- a/Views/Templates/Edit.cshtml
+++ b/Views/Templates/Edit.cshtml
@@ -11,19 +11,18 @@
             <a class="btn-small" asp-action="Index">Back</a>
         </div>
         <input asp-for="Name" placeholder="Template name" />
-        <div class="mt-2 mb-4">
-            <button type="submit" class="btn-small btn-ok-soft">Save</button>
-        </div>
-        <h5 class="mb-3">Columns</h5>
+        <h5 class="my-3">Columns</h5>
 
         <div class="form-inline mb-3">
             <input type="hidden" name="templateId" value="@Model.Id" />
-            <input type="text" name="name" placeholder="Column name" />
-            <select name="mode">
-                <option value="FromList">FromList</option>
-                <option value="FormatString">FormatString</option>
-            </select>
-            <button type="submit" formaction="@Url.Action("AddColumn")" formmethod="post" formnovalidate class="btn-small btn-ok-soft">Add Column</button>
+            <div class="input-group">
+                <input type="text" name="name" placeholder="Column name" class="form-control" />
+                <select name="mode" class="form-select">
+                    <option value="FromList">FromList</option>
+                    <option value="FormatString">FormatString</option>
+                </select>
+            </div>
+            <button type="submit" formaction="@Url.Action("AddColumn")" formmethod="post" formnovalidate class="btn-small btn-ok-soft ms-2">Add Column</button>
         </div>
 
         <div class="table-responsive table-fixed">
@@ -31,8 +30,7 @@
                 <thead>
                     <tr>
                         <th style="width:42px;"></th>
-                        <th style="min-width:180px;">Name</th>
-                        <th style="min-width:140px;">Mode</th>
+                        <th style="min-width:320px;">Name / Mode</th>
                         <th>Config</th>
                         <th style="min-width:100px;"></th>
                     </tr>
@@ -43,16 +41,14 @@
     var c = Model.Columns[i];
     <tr data-id="@c.Id">
         <td><span class="drag-handle" title="Drag to reorder">☰</span></td>
-        <td><input type="text" name="Columns[@i].Name" value="@c.Name" /></td>
         <td>
-            <select name="Columns[@i].Mode" class="mode-select">
-                <option value="FromList" selected="@(c.Mode == SqlDummySeeder.Excel.Models.ColumnValueMode.FromList)">
-                    FromList
-                </option>
-                <option value="FormatString" selected="@(c.Mode == SqlDummySeeder.Excel.Models.ColumnValueMode.FormatString)">
-                    FormatString
-                </option>
-            </select>
+            <div class="input-group">
+                <input type="text" name="Columns[@i].Name" value="@c.Name" class="form-control" />
+                <select name="Columns[@i].Mode" class="form-select mode-select">
+                    <option value="FromList" selected="@(c.Mode == SqlDummySeeder.Excel.Models.ColumnValueMode.FromList)">FromList</option>
+                    <option value="FormatString" selected="@(c.Mode == SqlDummySeeder.Excel.Models.ColumnValueMode.FormatString)">FormatString</option>
+                </select>
+            </div>
         </td>
         <td>
             <input type="hidden" name="Columns[@i].Id" value="@c.Id" />
@@ -86,7 +82,8 @@
         </div>
 
         <div class="mt-3">
-            <a class="btn-small btn-warn-soft export-link" asp-action="Export" asp-route-id="@Model.Id">Export</a>
+            <button type="submit" class="btn-small btn-ok-soft">Save</button>
+            <a class="btn-small btn-warn-soft export-link ms-2" asp-action="Export" asp-route-id="@Model.Id">Export</a>
         </div>
     </div>
 </form>


### PR DESCRIPTION
## Summary
- Merge template name and columns sections into a single card for a more compact edit view

## Testing
- `/root/.dotnet/dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68bc0e754990832aa185a67a32e82490